### PR TITLE
Proposed REST API interface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+  - repo: https://github.com/cpplint/cpplint
+    rev: 1.6.1
+    hooks:
+      - id: cpplint
+        name: cpplint
+        entry: cpplint
+        language: python
+        types: [c, c++]
+        args:
+          - --quiet
+          - --verbose=0
+          - --extensions=h,hpp,hxx,c,cc,cpp,cxx

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,14 @@
+set noparent
+filter=-whitespace/line_length
+filter=-legal/copyright
+filter=-build/header_guard
+filter=-build/include_order
+filter=-whitespace/braces
+filter=-runtime/indentation_namespace
+filter=-whitespace/indent
+filter=-readability/namespace
+filter=-whitespace/comments
+extensions=h,hpp,hxx,c,cc,cpp,cxx
+linelength=120
+root=.
+exclude_files=^build/|^out/|^third_party/

--- a/include/CommunicationLibrary/CommBuffer.h
+++ b/include/CommunicationLibrary/CommBuffer.h
@@ -1,0 +1,80 @@
+#ifndef COMMUNICATIONLIBRARY_COMMBUFFER_H_
+#define COMMUNICATIONLIBRARY_COMMBUFFER_H_
+
+#include <array>
+#include <cstddef>
+#include <span>
+
+namespace CommunicationLibrary
+{
+    namespace Buffer
+    {
+        //! @brief Fixed-capacity character buffer for communication payloads.
+        //! @details Zero-allocation, caller-owned buffer. Provides a writable span for transports.
+        template<std::size_t Capacity>
+        class CommBuffer
+        {
+            public:
+                //! @brief Obtain a writable span over the entire buffer capacity.
+                std::span<char> span() { return std::span<char>(storage_.data(), storage_.size()); }
+
+                //! @brief Raw pointer to underlying storage.
+                char* data() { return storage_.data(); }
+
+                //! @brief Capacity in bytes.
+                static constexpr std::size_t capacity() { return Capacity; }
+
+            private:
+                std::array<char, Capacity> storage_{};
+        };
+
+        //! @brief Simple fixed-size pool of fixed-capacity communication buffers.
+        //! @details Lock-free via naive busy flag; intended for single-threaded or externally synchronized use.
+        template<std::size_t PoolSize, std::size_t Capacity>
+        class CommPool
+        {
+            public:
+                //! @brief Acquire a free buffer index.
+                //! @return Index [0, PoolSize) on success, or -1 if none available.
+                int acquire()
+                {
+                    for (std::size_t i = 0; i < PoolSize; ++i)
+                    {
+                        if (!in_use_[i])
+                        {
+                            in_use_[i] = true;
+                            return static_cast<int>(i);
+                        }
+                    }
+                    return -1;
+                }
+
+                //! @brief Release a previously acquired buffer index.
+                void release(int index)
+                {
+                    if (index >= 0 && static_cast<std::size_t>(index) < PoolSize)
+                    {
+                        in_use_[static_cast<std::size_t>(index)] = false;
+                    }
+                }
+
+                //! @brief Writable span for a given buffer index.
+                std::span<char> span(int index)
+                {
+                    return buffers_[static_cast<std::size_t>(index)].span();
+                }
+
+                //! @brief Convenience to get raw pointer for a buffer index.
+                char* data(int index)
+                {
+                    return buffers_[static_cast<std::size_t>(index)].data();
+                }
+
+            private:
+                std::array<CommBuffer<Capacity>, PoolSize> buffers_{};
+                std::array<bool, PoolSize> in_use_{};
+        };
+    }
+}
+
+#endif  // COMMUNICATIONLIBRARY_COMMBUFFER_H_

--- a/include/CommunicationLibrary/RestInterface.h
+++ b/include/CommunicationLibrary/RestInterface.h
@@ -1,9 +1,9 @@
 #ifndef REST_INTERFACE_H
 #define REST_INTERFACE_H
 
-#include <concepts>
 #include <string_view>
 #include <cstddef>
+#include <span>
 
 
 
@@ -34,26 +34,17 @@ namespace CommunicationLibrary
             std::size_t body_size;
         };
 
-        template<typename T>
         class RestInterface
         {
             public:
                 virtual ~RestInterface() = default;
-
-                RestInterface(const std::string_view& routeTable);
-                RestInterface(const std::string_view& routeTable, const std::string_view& baseUrl);
-                RestInterface(const std::string_view& routeTable, const std::string_view& baseUrl, const std::string_view& apiKey);
-                RestInterface(const std::string_view& routeTable, const std::string_view& baseUrl, const std::string_view& apiKey, const std::string_view& apiSecret);
-                RestInterface(const std::string_view& routeTable, const std::string_view& baseUrl, const std::string_view& apiKey, const std::string_view& apiSecret, const std::string_view& apiToken);
-                RestInterface(const std::string_view& routeTable, const std::string_view& baseUrl, const std::string_view& apiKey, const std::string_view& apiSecret, const std::string_view& apiToken, const std::string_view& apiBearer);
 
                 // Core REST verbs (request writes response into caller-provided buffer)
                 virtual response_info get(
                     const std::string_view& path,
                     const header_view* headers,
                     std::size_t header_count,
-                    char* out_body,
-                    std::size_t out_capacity) = 0;
+                    std::span<char> out_body) = 0;
 
                 virtual response_info head(
                     const std::string_view& path,
@@ -64,8 +55,7 @@ namespace CommunicationLibrary
                     const std::string_view& path,
                     const header_view* headers,
                     std::size_t header_count,
-                    char* out_body,
-                    std::size_t out_capacity) = 0;
+                    std::span<char> out_body) = 0;
 
                 virtual response_info post(
                     const std::string_view& path,
@@ -73,8 +63,7 @@ namespace CommunicationLibrary
                     const std::string_view& content_type,
                     const header_view* headers,
                     std::size_t header_count,
-                    char* out_body,
-                    std::size_t out_capacity) = 0;
+                    std::span<char> out_body) = 0;
 
                 virtual response_info put(
                     const std::string_view& path,
@@ -82,8 +71,7 @@ namespace CommunicationLibrary
                     const std::string_view& content_type,
                     const header_view* headers,
                     std::size_t header_count,
-                    char* out_body,
-                    std::size_t out_capacity) = 0;
+                    std::span<char> out_body) = 0;
 
                 virtual response_info patch(
                     const std::string_view& path,
@@ -91,8 +79,11 @@ namespace CommunicationLibrary
                     const std::string_view& content_type,
                     const header_view* headers,
                     std::size_t header_count,
-                    char* out_body,
-                    std::size_t out_capacity) = 0;
+                    std::span<char> out_body) = 0;
+            protected:
+                RestInterface() = default;
+                RestInterface(const RestInterface&) = default;
+                RestInterface& operator=(const RestInterface&) = default;
         };
     }
 }

--- a/include/CommunicationLibrary/RestInterface.h
+++ b/include/CommunicationLibrary/RestInterface.h
@@ -22,16 +22,24 @@ namespace CommunicationLibrary
 {
     namespace RestInterface
     {
+        //! @brief Lightweight header view used to pass request headers without ownership.
+        //! @details Names and values refer to caller-owned, null-terminated strings or string views.
+        //! The interface does not copy; lifetime must outlive the call.
         struct header_view
         {
             std::string_view name;
             std::string_view value;
         };
 
-        struct response_info
+        //! @brief Minimal HTTP response metadata.
+        //! @details Provides status code and body size written. Convertible to bool for success checks.
+        //! @pre Returned by interface methods only; users do not construct directly.
+        //! @post When used with output buffers, body_size indicates bytes written into the provided span.
+        struct http_response
         {
             int status_code;
             std::size_t body_size;
+            explicit operator bool() const { return status_code == 200; }
         };
 
         class RestInterface
@@ -39,25 +47,59 @@ namespace CommunicationLibrary
             public:
                 virtual ~RestInterface() = default;
 
-                // Core REST verbs (request writes response into caller-provided buffer)
-                virtual response_info get(
+                //! @brief HTTP GET request.
+                //! @details Writes response body into caller-provided buffer.
+                //! @param path Relative path from the configured base URL.
+                //! @param headers Pointer to an array of header_view entries (may be nullptr when header_count==0).
+                //! @param header_count Number of header entries provided.
+                //! @param out_body Caller-owned output span to write response bytes into.
+                //! @return http_response with status_code and body_size bytes written into out_body.
+                //! @pre `out_body.data()` is valid and `out_body.size()` reflects writable capacity.
+                //! @pre Each header_view strings must remain valid for the call duration.
+                //! @post `body_size <= out_body.size()`.
+                //! @post No ownership is taken; all buffers remain caller-owned.
+                virtual http_response get(
                     const std::string_view& path,
                     const header_view* headers,
                     std::size_t header_count,
                     std::span<char> out_body) = 0;
 
-                virtual response_info head(
+                //! @brief HTTP HEAD request.
+                //! @details No response body is written; headers/status only.
+                //! @param path Relative path from the configured base URL.
+                //! @param headers Pointer to an array of header_view entries (may be nullptr when header_count==0).
+                //! @param header_count Number of header entries provided.
+                //! @return http_response with status_code; body_size is zero.
+                virtual http_response head(
                     const std::string_view& path,
                     const header_view* headers,
                     std::size_t header_count) = 0;
 
-                virtual response_info delete_(
+                //! @brief HTTP DELETE request.
+                //! @details Writes response body into caller-provided buffer.
+                //! @param path Relative path from the configured base URL.
+                //! @param headers Pointer to an array of header_view entries (may be nullptr when header_count==0).
+                //! @param header_count Number of header entries provided.
+                //! @param out_body Caller-owned output span to write response bytes into.
+                //! @return http_response with status_code and body_size bytes written into out_body.
+                virtual http_response delete_(
                     const std::string_view& path,
                     const header_view* headers,
                     std::size_t header_count,
                     std::span<char> out_body) = 0;
 
-                virtual response_info post(
+                //! @brief HTTP POST request.
+                //! @details Sends a request body and writes response body into caller-provided buffer.
+                //! @param path Relative path from the configured base URL.
+                //! @param body Request body view; data must remain valid for the call duration.
+                //! @param content_type MIME content type of the request body (e.g., "application/json").
+                //! @param headers Pointer to an array of header_view entries (may be nullptr when header_count==0).
+                //! @param header_count Number of header entries provided.
+                //! @param out_body Caller-owned output span to write response bytes into.
+                //! @return http_response with status_code and body_size bytes written into out_body.
+                //! @pre `body` and `content_type` lifetimes outlive the call.
+                //! @post `body_size <= out_body.size()`.
+                virtual http_response post(
                     const std::string_view& path,
                     const std::string_view& body,
                     const std::string_view& content_type,
@@ -65,7 +107,10 @@ namespace CommunicationLibrary
                     std::size_t header_count,
                     std::span<char> out_body) = 0;
 
-                virtual response_info put(
+                //! @brief HTTP PUT request.
+                //! @details Sends a request body and writes response body into caller-provided buffer.
+                //! @copydetails post
+                virtual http_response put(
                     const std::string_view& path,
                     const std::string_view& body,
                     const std::string_view& content_type,
@@ -73,7 +118,10 @@ namespace CommunicationLibrary
                     std::size_t header_count,
                     std::span<char> out_body) = 0;
 
-                virtual response_info patch(
+                //! @brief HTTP PATCH request.
+                //! @details Sends a request body and writes response body into caller-provided buffer.
+                //! @copydetails post
+                virtual http_response patch(
                     const std::string_view& path,
                     const std::string_view& body,
                     const std::string_view& content_type,

--- a/include/CommunicationLibrary/RestInterface.h
+++ b/include/CommunicationLibrary/RestInterface.h
@@ -1,0 +1,100 @@
+#ifndef REST_INTERFACE_H
+#define REST_INTERFACE_H
+
+#include <concepts>
+#include <string_view>
+#include <cstddef>
+
+
+
+//! @brief CommunicationLibrary::RestInterface namespace
+//! @details This namespace defines the contract for the RestInterface classes
+//! This defines the interface needed for the concrete REST implementation for the devices
+//! This ensures both our devices use the same interface to communicate with the REST API
+//! Gateway will have an API and sensor packages will have REST API as well
+//! Sensor packages will POST to the Gateway REST API for sending data and GET from the Gateway REST API for receiving configuration
+//! Gateway will GET from sensor packages to check health
+//! Each device should have its own route table. Route table should be able to be given as a parameter to the constructor (by reference)
+//! Since we are targeting embedded platform, we cannot use std::map or std::unordered_map, or std::vector
+//! We will need string views into fixed size arrays or memory pools
+//! Each device will be responsible for using ArduinoJson or similar to parse and serialize JSON
+namespace CommunicationLibrary
+{
+    namespace RestInterface
+    {
+        struct header_view
+        {
+            std::string_view name;
+            std::string_view value;
+        };
+
+        struct response_info
+        {
+            int status_code;
+            std::size_t body_size;
+        };
+
+        template<typename T>
+        class RestInterface
+        {
+            public:
+                virtual ~RestInterface() = default;
+
+                RestInterface(const std::string_view& routeTable);
+                RestInterface(const std::string_view& routeTable, const std::string_view& baseUrl);
+                RestInterface(const std::string_view& routeTable, const std::string_view& baseUrl, const std::string_view& apiKey);
+                RestInterface(const std::string_view& routeTable, const std::string_view& baseUrl, const std::string_view& apiKey, const std::string_view& apiSecret);
+                RestInterface(const std::string_view& routeTable, const std::string_view& baseUrl, const std::string_view& apiKey, const std::string_view& apiSecret, const std::string_view& apiToken);
+                RestInterface(const std::string_view& routeTable, const std::string_view& baseUrl, const std::string_view& apiKey, const std::string_view& apiSecret, const std::string_view& apiToken, const std::string_view& apiBearer);
+
+                // Core REST verbs (request writes response into caller-provided buffer)
+                virtual response_info get(
+                    const std::string_view& path,
+                    const header_view* headers,
+                    std::size_t header_count,
+                    char* out_body,
+                    std::size_t out_capacity) = 0;
+
+                virtual response_info head(
+                    const std::string_view& path,
+                    const header_view* headers,
+                    std::size_t header_count) = 0;
+
+                virtual response_info delete_(
+                    const std::string_view& path,
+                    const header_view* headers,
+                    std::size_t header_count,
+                    char* out_body,
+                    std::size_t out_capacity) = 0;
+
+                virtual response_info post(
+                    const std::string_view& path,
+                    const std::string_view& body,
+                    const std::string_view& content_type,
+                    const header_view* headers,
+                    std::size_t header_count,
+                    char* out_body,
+                    std::size_t out_capacity) = 0;
+
+                virtual response_info put(
+                    const std::string_view& path,
+                    const std::string_view& body,
+                    const std::string_view& content_type,
+                    const header_view* headers,
+                    std::size_t header_count,
+                    char* out_body,
+                    std::size_t out_capacity) = 0;
+
+                virtual response_info patch(
+                    const std::string_view& path,
+                    const std::string_view& body,
+                    const std::string_view& content_type,
+                    const header_view* headers,
+                    std::size_t header_count,
+                    char* out_body,
+                    std::size_t out_capacity) = 0;
+        };
+    }
+}
+
+#endif // REST_INTERFACE_H


### PR DESCRIPTION
Jag föreställer mig att våra IoT-devices använder ett gemensamt REST-interface som vi kan importera. Det betyder att vi kan återanvända interfacet. Varje device får ha sin egen route table i nån slags std::array, som vi läser med string_view, då vi inte kan använda std::map i embedded.